### PR TITLE
Add fn's to retrieve ident(s) for named item(s) and entity(ies) for given ident(s)

### DIFF
--- a/src/keechma/entitydb/core.cljs
+++ b/src/keechma/entitydb/core.cljs
@@ -338,6 +338,20 @@
       #(get-entity store (:type %) (:id %) query)
       entity-idents))))
 
+(defn get-ident-for-named [store entity-name]
+  (get-in store [:entitydb.named/item entity-name :data]))
+
+(defn get-idents-for-collection [store collection-name]
+  (get-in store [:entitydb.named/collection collection-name :data]))
+
+(defn get-entity-from-ident
+  ([store entity-ident] (get-entity-from-ident store entity-ident nil))
+  ([store entity-ident query] (get-entity store (:type entity-ident) (:id entity-ident) query)))
+
+(defn get-entities-from-idents
+  ([store entity-idents] (get-entities-from-idents store entity-idents nil))
+  ([store entity-idents query] (mapv #(get-entity store (:type %) (:id %) query) entity-idents)))
+
 (defn remove-named [store entity-name]
   (dissoc-in store [:entitydb.named/item entity-name]))
 


### PR DESCRIPTION
In order to pass only idents around without exposing the data stored in the entitydb two  functions are added that enable retrieving ident(s) via named-entity or named-collection and two more functions that retrieve entities for said ident(s)